### PR TITLE
removing dependency on specific selenium version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
               'selene.support',
               'selene.support.conditions'],
     include_package_data=True,
-    install_requires=['selenium==2.53.1', 'webdriver_manager', 'future', 'backports.functools_lru_cache', 'six'],
+    install_requires=['selenium', 'webdriver_manager', 'future', 'backports.functools_lru_cache', 'six'],
     platforms='any',
     zip_safe=False,
     keywords=['testing', 'selenium', 'selenide', 'browser', 'pageobject', 'widget', 'wrapper'],


### PR DESCRIPTION
this makes setup.py agree with Pipfile and Pipfile.lock

This fix allows people to install the library and dependencies (selenium >=3.0) by using a command like:
```
pipenv install -e git+https://github.com/SergeyPirogov/selene.git@feature/pipenv#egg=selene
```

or include the git repo in a Pipfile along with other libraries that require selenium >=3.0